### PR TITLE
changed property in sort field to match entity's

### DIFF
--- a/src/lib/Editors/TagFilter/Settings.vue
+++ b/src/lib/Editors/TagFilter/Settings.vue
@@ -55,14 +55,14 @@ export default {
           text: 'Publish Date (earliest)',
           sortType: 'date',
           fields: {
-            publishDate: 1,
+            lastPublished: 1,
           },
         },
         {
           text: 'Publish Date (latest)',
           sortType: 'date',
           fields: {
-            publishDate: -1,
+            lastPublished: -1,
           },
         },
       ],


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
changing property name on sort fields to match property name on document

- **What is the current behavior?** (You can also link to an open issue here)
an object is passed as a sort query, with a property "publishDate". The documents don't have that property, so the sort query has no effect.

- **What is the new behavior (if this is a feature change)?**
using last Published property the sort query works as expected

- **Other information**:
This is a property on the Page document, and it seems to match what we set on whppt-nuxt.